### PR TITLE
Fix int type declaration

### DIFF
--- a/lib/gccjit.ml
+++ b/lib/gccjit.ml
@@ -250,7 +250,7 @@ module Type = struct
     | Complex_long_double -> GCC_JIT_TYPE_COMPLEX_LONG_DOUBLE
 
   let get ctx kind = wrap2 ctx gcc_jit_context_get_type ctx (type_kind kind)
-  let int ctx ?(signed = false) n = wrap3 ctx gcc_jit_context_get_int_type ctx (if signed then 1 else 0) n
+  let int ctx ?(signed = false) n = wrap3 ctx gcc_jit_context_get_int_type ctx n (if signed then 1 else 0)
 
   let pointer typ =
     let ctx = gcc_jit_object_get_context (gcc_jit_type_as_object typ) in

--- a/test/expect_tests.ml
+++ b/test/expect_tests.ml
@@ -49,3 +49,16 @@ let%expect_test "square" =
   (* Now try running the code *)
   let () = print_endline @@ Int.to_string @@ callable 5 in
   [%expect {| 25 |}]
+
+
+let%expect_test "int type declaration" =
+  let ctx = Context.create () in
+  let typ = Type.int ctx ~signed:true 4 in
+
+  print_endline (Type.to_string typ);
+  [%expect {| int |}];
+
+  let typ = Type.int ctx ~signed:false 1 in
+
+  print_endline (Type.to_string typ);
+  [%expect {| unsigned char |}]


### PR DESCRIPTION
The sign and int type parameters were permuted.

See https://gcc.gnu.org/onlinedocs/jit/topics/types.html#c.gcc_jit_context_get_int_type